### PR TITLE
FIX-JENKINS-44199 Allow custom name spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jenkins-cd/preferences",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Jenkins BlueOcean preference storage via localStorage",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-cli": "6.24.1",
     "babel-preset-es2015": "6.24.1",
     "jasmine": "2.5.3",
-    "jsdoc": "3.4.3"
+    "jsdoc": "3.4.3",
+    "jsdom": "10.1.0"
   }
 }

--- a/preferences/Preference.js
+++ b/preferences/Preference.js
@@ -1,6 +1,5 @@
 // See https://github.com/jenkinsci/js-storage
-const storage = require('@jenkins-cd/storage/storage');
-const StorageNamespace = require('@jenkins-cd/storage/StorageNamespace');
+const storage = require('@jenkins-cd/storage');
 
 const DEFAULT_NS_NAME = 'jenkins-preferences';
 
@@ -17,7 +16,8 @@ const DEFAULT_NS_NAME = 'jenkins-preferences';
  * preference.newPreference('key', ['defaultValue', 'allowedValues', 'namespace']);
  */
 function Preference(key, defaultValue, allowedValues, namespace ) {
-    const preferences = new StorageNamespace(namespace || DEFAULT_NS_NAME, storage.local);
+
+    const preferences = storage.localNamespace(namespace || DEFAULT_NS_NAME);
     if (key === undefined) {
         throw new Error('Cannot create preference. Preference "key" name must be specified.');
     }

--- a/preferences/Preference.js
+++ b/preferences/Preference.js
@@ -1,7 +1,9 @@
 // See https://github.com/jenkinsci/js-storage
-const storage = require('@jenkins-cd/storage');
-const jenkinsNS = storage.jenkinsNamespace();
-const preferences = jenkinsNS.subspace('preferences');
+const storage = require('@jenkins-cd/storage/storage');
+const StorageNamespace = require('@jenkins-cd/storage/StorageNamespace');
+
+const DEFAULT_NS_NAME = 'jenkins-preferences';
+
 /**
  * This uses the localStorage to store and read from. We use a simple
  * key:value in the localStorage but further expose the allowedValues
@@ -9,11 +11,13 @@ const preferences = jenkinsNS.subspace('preferences');
  * @param {string} key - the key we want to store
  * @param {string} [defaultValue] - if no value is set in the storage we will set this value
  * @param {Array} [allowedValues] - an array of known values that should be supported
+ * @param {string} [namespace] - if no value we use default namespace
  * @constructor
  * @example
- * preference.newPreference('key', 'defaultValue', ['defaultValue', 'allowedValues']);
+ * preference.newPreference('key', ['defaultValue', 'allowedValues', 'namespace']);
  */
-function Preference(key, defaultValue, allowedValues) {
+function Preference(key, defaultValue, allowedValues, namespace ) {
+    const preferences = new StorageNamespace(namespace || DEFAULT_NS_NAME, storage.local);
     if (key === undefined) {
         throw new Error('Cannot create preference. Preference "key" name must be specified.');
     }
@@ -56,8 +60,11 @@ Preference.prototype = {
  * @param {string} key The key name. Use dot separated naming convention to create a key hierarchy (ala Log4J).
  * @param {string} [defaultValue] The default value we want to use if nothing is set
  * @param {Array} [allowedValues] Array of known supported values
+ * @param {string} [namespace] - if no value we use default namespace
  * @returns {Preference} The {Preference} instance.
  */
-exports.newPreference = function (key, defaultValue, allowedValues) {
-    return new Preference(key, defaultValue, allowedValues);
+exports.newPreference = function (key, defaultValue, allowedValues, namespace) {
+    return new Preference(key, defaultValue, allowedValues, namespace);
 };
+
+exports.DEFAULT_NS_NAME = DEFAULT_NS_NAME;

--- a/preferences/Preference.js
+++ b/preferences/Preference.js
@@ -17,14 +17,14 @@ const DEFAULT_NS_NAME = 'jenkins-preferences';
  */
 function Preference(key, defaultValue, allowedValues, namespace ) {
 
-    const preferences = storage.localNamespace(namespace || DEFAULT_NS_NAME);
+    this.preferences = storage.localNamespace(namespace || DEFAULT_NS_NAME);
     if (key === undefined) {
         throw new Error('Cannot create preference. Preference "key" name must be specified.');
     }
     this.key = key;
-    let value = preferences.get(key);
+    let value = this.preferences.get(key);
     if (!value && defaultValue) {
-        preferences.set(key, defaultValue);
+        this.preferences.set(key, defaultValue);
         value = defaultValue;
     }
     this.value = value;
@@ -37,7 +37,7 @@ Preference.prototype = {
      * @param newValue
      */
     set newValue(newValue) {
-        preferences.set(this.key, newValue);
+        this.preferences.set(this.key, newValue);
         this.value = newValue;
     },
     /**

--- a/preferences/Preferences.js
+++ b/preferences/Preferences.js
@@ -2,7 +2,8 @@ const preference = require('./Preference');
 /**
  * Creates a configuration object based on preferences.
  * This means we use localStorage to interact with the components.
- * @param preferencesArray {array} the preferences that we want to sync with the local storage
+ * @param preferencesArray {Array} the preferences that we want to sync with the local storage
+ * @param {string} [namespace] - if no value we use default namespace
  * @constructor
  * @example
  * const preferencesArray = [{
@@ -28,14 +29,14 @@ const preference = require('./Preference');
  * ];
  * const karaokeConfig = preferences.newPreferences(preferencesArray);
  */
-function Preferences(preferencesArray) {
+function Preferences(preferencesArray, namespace) {
     if (!preferencesArray) {
         throw new Error('Cannot create config. Must pass an array of properties!');
     }
     this.store = {};
     // store the keys we know
     this.keys = preferencesArray.map((item) => {
-        this.store[item.key] = preference.newPreference(item.key, item.defaultValue, item.allowedValues);
+        this.store[item.key] = preference.newPreference(item.key, item.defaultValue, item.allowedValues, namespace);
         return item.key;
     });
 }
@@ -50,7 +51,7 @@ Preferences.prototype = {
     },
     /**
      * Returns all registered keys
-     * @returns {array}
+     * @returns {Array}
      */
     getKeys() {
         return this.keys;
@@ -59,8 +60,9 @@ Preferences.prototype = {
 /**
  * Create a Preference and return this config
  * @param preferencesArray the preferences that we want to sync with the local storage
+ * @param {string} [namespace] - if no value we use default namespace
  * @returns {Preferences}
  */
-exports.newPreferences = function (preferencesArray) {
-    return new Preferences(preferencesArray);
+exports.newPreferences = function (preferencesArray, namespace) {
+    return new Preferences(preferencesArray, namespace);
 };

--- a/preferences/StorageMock.js
+++ b/preferences/StorageMock.js
@@ -1,0 +1,23 @@
+// Storage Mock
+module.exports = function storageMock() {
+    const storage = {};
+
+    return {
+        setItem: function(key, value) {
+            storage[key] = value || '';
+        },
+        getItem: function(key) {
+            return key in storage ? storage[key] : undefined;
+        },
+        removeItem: function(key) {
+            delete storage[key];
+        },
+        get length() {
+            return Object.keys(storage).length;
+        },
+        key: function(i) {
+            const keys = Object.keys(storage);
+            return keys[i] || undefined;
+        },
+    };
+};

--- a/preferences/index.js
+++ b/preferences/index.js
@@ -1,2 +1,3 @@
 exports.preference = require('./Preference');
 exports.preferences = require('./Preferences');
+exports.storageMock = require('./StorageMock');

--- a/spec/_init-tests-spec.js
+++ b/spec/_init-tests-spec.js
@@ -1,0 +1,28 @@
+/**
+ * THIS IS NOT A TEST SUITE !!
+ *
+ * This module performs some initialization of the DOM.
+ *
+ */
+const jsdom = require('jsdom');
+const { JSDOM } = jsdom;
+const storageMock = require('../preferences/StorageMock');
+
+// code to boostrap mount with JSDOM
+// see: https://github.com/airbnb/enzyme/blob/master/docs/guides/jsdom.md
+const exposedProperties = ['window', 'navigator', 'document'];
+let dom = new JSDOM(`<!DOCTYPE html><p>Hello world</p>`);
+global.document =  dom.window.document;
+global.window = document.defaultView;
+global.window.localStorage = storageMock();
+
+Object.keys(document.defaultView).forEach((property) => {
+    if (typeof global[property] === 'undefined') {
+        exposedProperties.push(property);
+        global[property] = document.defaultView[property];
+    }
+});
+
+global.navigator = {
+    userAgent: 'node.js',
+};

--- a/spec/preferences-spec.js
+++ b/spec/preferences-spec.js
@@ -58,3 +58,42 @@ describe("Preferences smoke testing", function () {
         expect(prop.getAllowedValues()).toEqual(['default', 'never']);
     });
 });
+
+describe("Preferences should be found in the localStorage direct access", function () {
+    const preferences = require('../preferences/Preferences');
+    const karaokeConfig = preferences.newPreferences(preferencesArray);
+    const localStorage = window.localStorage;
+    const PREFIX = 'jenkins-preferences:';
+    let key = 'xxx4u';
+    it("returns undefined", function () {
+        const prop = karaokeConfig.getPreference(key);
+        expect(prop).toBe(undefined);
+        // validate windows
+        expect(prop).toBe(localStorage.getItem(PREFIX + key));
+    });
+    it("returns defaultValue", function () {
+        key = 'runDetails.logView';
+        const prop = karaokeConfig.getPreference(key);
+        expect(prop.value).toBe('pipeline');
+        // validate windows
+        expect(prop.value).toBe(window.localStorage.getItem(PREFIX + key));
+    });
+    it("returns defaultValue and allowedValues", function () {
+        key = 'runDetails.pipeline.showPending';
+        const prop = karaokeConfig.getPreference(key);
+        expect(prop.value).toBe('default');
+        // validate windows
+        expect(prop.value).toBe(window.localStorage.getItem(PREFIX + key));
+        expect(prop.getAllowedValues()).toEqual(['default', 'never']);
+    });
+    it("test that we can add to different namespace and do not delete old one", function () {
+        const preference = require('../preferences/Preference');
+        const newNs = 'xxx';
+        key = 'runDetails.pipeline.showPending';
+        preference.newPreference(key, 'never', undefined, newNs);
+        const prop = karaokeConfig.getPreference(key);
+        expect(prop.value).toBe('default');
+        // validate windows
+        expect('never').toBe(window.localStorage.getItem(newNs + ':' + key));
+    });
+});


### PR DESCRIPTION
Fixes https://issues.jenkins-ci.org/browse/JENKINS-44199 by allowing custom name space and using a different namespace as 

```
var JENKINS_NS_NAME = 'jenkins-instance';
```

to make sure preferences do not get deleted when updating. 